### PR TITLE
Fixing permissions on button action multi-select fields

### DIFF
--- a/core/admin/admin.py
+++ b/core/admin/admin.py
@@ -24,7 +24,7 @@ def _filter_button_actions(request):
     organizations = Organization.objects.filter(organization_users__user=request.user)
     org_users = User.objects.filter(organizations_organization__in=organizations)
     phones = Phone.objects.filter(user__in=org_users)
-    return  ButtonAction.objects.filter(target_user__in=phones)
+    return ButtonAction.objects.filter(target_user__in=phones)
 
 
 class ButtonAdmin(admin.ModelAdmin):

--- a/core/admin/tests.py
+++ b/core/admin/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.db.models.fields.related import ManyToManyField
 
 from ..models import Button, ButtonAction, Phone
 
@@ -89,6 +90,43 @@ class AdminTestCase(TestCase):
         self.assertEqual(list(ba.get_queryset(non_superuser_request)),
                          list(Button.objects.filter(organization=self.organization)))
 
+    def test_button_formfield_for_manytomany(self):
+        non_superuser_request = MockRequest()
+        non_superuser_request.user = self.user1
+
+        ba = ButtonAdmin(Button, self.site)
+        kwargs = {}
+        single_press_dbfield = \
+            self.button1.single_press_actions.instance._meta.get_field("single_press_actions")
+        double_press_dbfield = \
+            self.button1.single_press_actions.instance._meta.get_field("double_press_actions")
+        long_press_dbfield = \
+            self.button1.single_press_actions.instance._meta.get_field("long_press_actions")
+
+        single_press_field = (ba.formfield_for_manytomany(single_press_dbfield,
+                                          non_superuser_request,
+                                          **kwargs))
+        double_press_field = (ba.formfield_for_manytomany(double_press_dbfield,
+                                          non_superuser_request,
+                                          **kwargs))
+        long_press_field = (ba.formfield_for_manytomany(long_press_dbfield,
+                                          non_superuser_request,
+                                          **kwargs))
+
+        superuser_single_press_field = (ba.formfield_for_manytomany(single_press_dbfield,
+                                          self.superuser_request,
+                                          **kwargs))
+
+        self.assertEqual(list(superuser_single_press_field.queryset),
+                         list(ButtonAction.objects.all()))
+        self.assertEqual(list(single_press_field.queryset).sort(),
+                         list(ButtonAction.objects.filter(target_user=self.phone)).sort())
+        self.assertEqual(list(double_press_field.queryset).sort(),
+                         list(ButtonAction.objects.filter(target_user=self.phone)).sort())
+        self.assertEqual(list(long_press_field.queryset).sort(),
+                         list(ButtonAction.objects.filter(target_user=self.phone)).sort())
+
+
     def test_phone_queryset(self):
         non_superuser_request = MockRequest()
         non_superuser_request.user = self.user1
@@ -133,8 +171,8 @@ class AdminTestCase(TestCase):
         non_superuser_request = MockRequest()
         non_superuser_request.user = self.user1
 
-        ba = ButtonActionAdmin(ButtonAction, self.site)
-        self.assertEqual(list(ba.get_queryset(self.superuser_request)),
+        baa = ButtonActionAdmin(ButtonAction, self.site)
+        self.assertEqual(list(baa.get_queryset(self.superuser_request)),
                          list(ButtonAction.objects.all()))
-        self.assertEqual(list(ba.get_queryset(non_superuser_request)).sort(),
+        self.assertEqual(list(baa.get_queryset(non_superuser_request)).sort(),
                          list(ButtonAction.objects.filter(target_user=self.phone)).sort())

--- a/core/admin/tests.py
+++ b/core/admin/tests.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.db.models.fields.related import ManyToManyField
 
 from ..models import Button, ButtonAction, Phone
 
@@ -104,18 +103,18 @@ class AdminTestCase(TestCase):
             self.button1.single_press_actions.instance._meta.get_field("long_press_actions")
 
         single_press_field = (ba.formfield_for_manytomany(single_press_dbfield,
-                                          non_superuser_request,
-                                          **kwargs))
+                              non_superuser_request,
+                              **kwargs))
         double_press_field = (ba.formfield_for_manytomany(double_press_dbfield,
-                                          non_superuser_request,
-                                          **kwargs))
+                              non_superuser_request,
+                              **kwargs))
         long_press_field = (ba.formfield_for_manytomany(long_press_dbfield,
-                                          non_superuser_request,
-                                          **kwargs))
+                            non_superuser_request,
+                            **kwargs))
 
         superuser_single_press_field = (ba.formfield_for_manytomany(single_press_dbfield,
-                                          self.superuser_request,
-                                          **kwargs))
+                                        self.superuser_request,
+                                        **kwargs))
 
         self.assertEqual(list(superuser_single_press_field.queryset),
                          list(ButtonAction.objects.all()))
@@ -125,7 +124,6 @@ class AdminTestCase(TestCase):
                          list(ButtonAction.objects.filter(target_user=self.phone)).sort())
         self.assertEqual(list(long_press_field.queryset).sort(),
                          list(ButtonAction.objects.filter(target_user=self.phone)).sort())
-
 
     def test_phone_queryset(self):
         non_superuser_request = MockRequest()


### PR DESCRIPTION
@oliverbhull Please allow me to walk you through what's going on here so you can review it to the best of your abilities. Having a second set of eyes on this would be a good safety measure.

**To reproduce the problem that this fixes**
1. Make sure you're on the master branch.
2. Create three users in the admin panel and assign them staff access but not superuser access. Make sure they all have phone numbers
3. Create two organizations
4. Using the "Organization User" admin section, add 2 users to one organization and 1 user to the other
5. Create a button in each organization and add a bunch of actions to each.

What you'll notice is that if you log in as a superuser you should always be able to see all of the actions in the system when you create or edit a button. This is expected and normal. However, if you go to the user listing page and click one of the"hijack buttons" to view the admin as a user, then you still see all the actions. This is bad.

![image](https://cloud.githubusercontent.com/assets/106148/26524996/3d156e84-4316-11e7-997d-69224c406a96.png)

This commit fixes this. The django admin panel exposes a function called `formfield_for_manytomany` that allows us to hook into those multi select fields and edit their so-called "querysets." This function takes a db_field argument, a request argument, and some optional keyword arguments.

Following "Test Driven Development" or TDD, I wrote a test first. You can see it [here](https://github.com/aphelionz/dingdongdash/pull/27/files#diff-06ecb0f6046da1e1ae44ff2b63756949). It mocks a request, mocks db_field arguments, and passes empty keyword arguments to the function. Then it compares the querysets to the expected value.

This test should failed at first, expectedly, until I wrote the corresponding code to fix it. That code is in admin.py, [here](https://github.com/aphelionz/dingdongdash/pull/27/files#diff-6dcc2593045bbe7f9d4731552d4fcf1b). The `_filter_button_actions` function does the heavy lifting and it's called in both the `ButtonAdmin` and `ButtonActionAdmin` classes, each of which describe admin panel behavior for the corresponding `Button` and `ButtonAction` models.

Let me know if you have any questions. Then I'll need a stamp of approval from you and I'll go ahead and merge it.